### PR TITLE
Separate company-specific config into a private chezmoi source

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,4 +1,6 @@
 {{- $email := promptStringOnce . "email" "Email address" -}}
+{{- $work  := promptBoolOnce  . "work"  "Is this a work device" -}}
 
 [data]
     email = {{ $email | quote }}
+    work  = {{ $work }}

--- a/README.md
+++ b/README.md
@@ -64,6 +64,80 @@ Useful workflow:
 3. apply them with `chezmoi apply`
 4. commit the updated source files from the repo
 
+## Keeping work / company config separate
+
+This repo is **public**, so anything company-specific (employer-internal aliases,
+env vars, infra names, secrets, AI assistant rules) is kept out of it entirely.
+Instead, that config lives in a separate **private** repo managed as a *second
+chezmoi source*, and this public repo only carries generic, company-agnostic
+hooks that pick it up when present. Nothing here names any employer.
+
+The hooks already wired into this repo:
+
+- **`.zshrc`** sources every `~/.config/zsh/local/*.zsh` if that directory exists
+  (a no-op on a personal machine where it doesn't):
+  ```sh
+  if [ -d "$HOME/.config/zsh/local" ]; then
+      for f in "$HOME"/.config/zsh/local/*.zsh(N); do source "$f"; done
+  fi
+  ```
+- **`.zsh/zsh_alias`** defines `czw`, a chezmoi wrapper pointed at the private
+  source (harmless if that source isn't cloned):
+  ```sh
+  alias czw='chezmoi --source ~/.local/share/chezmoi-work --config ~/.config/chezmoi/chezmoi-work.toml'
+  ```
+- **`dot_claude/CLAUDE.md.tmpl`** holds only generic Claude rules and
+  conditionally imports company rules when the machine is flagged as work:
+  ```
+  {{ if .work }}@work-rules.md{{ end }}
+  ```
+- **`.chezmoi.toml.tmpl`** prompts once per machine for the `work` flag that
+  gates that import.
+
+Because the directory is named generically (`chezmoi-work`, not any company
+name), the exact same setup works for **any future employer** — just point a new
+private repo at it.
+
+### Setting it up at a new company
+
+1. Create a **private** repo for the company config (e.g. `acme-dotfiles`).
+2. Clone it to the generic local path:
+   ```sh
+   git clone git@github.com:<you>/acme-dotfiles.git ~/.local/share/chezmoi-work
+   ```
+3. Give the private source its own chezmoi config at
+   `~/.config/chezmoi/chezmoi-work.toml` (add the `[age]` block only if you want
+   encrypted secrets — see below):
+   ```toml
+   # encryption = "age"
+   # [age]
+   #     identity  = "~/.config/chezmoi/key.txt"
+   #     recipient = "age1...."
+   ```
+4. Put company config in the private source, mapping to the generic targets this
+   repo already loads:
+   - shell: `dot_config/zsh/local/*.zsh` → `~/.config/zsh/local/*.zsh`
+   - Claude rules: `dot_claude/work-rules.md` → `~/.claude/work-rules.md`
+     (imported automatically by the public `CLAUDE.md` when `work=true`)
+   - anything else company-specific under `~/.claude/`, etc.
+5. Flag work machines: run `chezmoi init` (it now prompts "Is this a work
+   device") or add `work = true` under `[data]` in `~/.config/chezmoi/chezmoi.toml`.
+6. Apply both sources — generic with `chezmoi apply`, company with `czw apply`.
+
+### Secrets (optional, via age)
+
+Keep real secrets encrypted **in the private repo only** — never here:
+
+```sh
+brew install age
+age-keygen -o ~/.config/chezmoi/key.txt   # back the key up in a password manager
+# put the printed public key as `recipient` in chezmoi-work.toml, uncomment [age]
+czw add --encrypt ~/.config/zsh/local/secrets.zsh
+```
+
+chezmoi stores them as `encrypted_*.age` and decrypts on `czw apply`. The key
+file is the only way to decrypt them and is never committed.
+
 ## Migration note
 
 The older version of this repository included custom installation scripts,

--- a/dot_claude/CLAUDE.md.tmpl
+++ b/dot_claude/CLAUDE.md.tmpl
@@ -1,0 +1,30 @@
+# User-Level Claude Rules
+
+## Git Push
+
+Pushing to a branch that has not yet been merged is fine — no confirmation needed. This includes pushing new commits to an open PR's branch, or pushing a new feature branch upstream for the first time.
+
+Still ask for confirmation before:
+- Pushing to `main`/`master` or any other protected/default branch
+- Force-pushing (`--force`, `--force-with-lease`) to a branch that has already been merged
+- Any push that would rewrite history on a shared/merged branch
+
+## Volta (Node version manager)
+
+I use [Volta](https://volta.sh) to manage Node versions. It is installed via Homebrew; the shims live at `~/.volta/bin` and `~/.zshrc` puts that directory at the front of `PATH`.
+
+**How it works:** Volta installs shims for `node`, `npm`, `npx`, `yarn`. When any of those run, the shim looks at the nearest `package.json` for a `"volta": { "node": "X.Y.Z" }` field and transparently execs that exact Node version. No `nvm use`, no per-command `PATH` munging.
+
+**Project pins:** the authoritative Node version for a project lives in its `package.json` under `"volta"`.
+
+**If npm/node behaves wrong, run these diagnostics in order:**
+
+1. `which node && which npm` — should resolve to something under `~/.volta/bin/`. If it points at `/opt/homebrew/...`, `/usr/local/...`, or `~/.nvm/...`, Volta's shims aren't winning on `PATH`. Check `echo $PATH` — `~/.volta/bin` must appear before any other Node source.
+2. `node --version` from inside the project directory — should match the `"volta"` pin in that project's `package.json`. If it doesn't, Volta probably hasn't downloaded that version yet: run `volta install node@<version>` (the version from `package.json`) to cache it.
+3. `volta list` — shows installed Node versions and any pins Volta resolved for the current directory.
+4. `cat package.json | jq .volta` (or grep) — confirm the project actually has a pin. If it doesn't, that's the bug; add one with `volta pin node@<version>`.
+
+**Do not** suggest `PATH=...` prefixes, `nvm use`, or other workarounds as the fix. The fix is always: get Volta's shims on `PATH` and make sure the project has a `volta` pin.
+{{ if .work }}
+@work-rules.md
+{{- end }}

--- a/dot_zsh/zsh_alias
+++ b/dot_zsh/zsh_alias
@@ -5,4 +5,5 @@ if type nvim >/dev/null 2>&1; then
     alias vim="nvim"
 fi
 
-alias kafka='docker compose -f $HOME/acrisure/docker-compose-kafka.yaml up -d; echo "\n\nKafka is now running. See admin console at http://localhost:28028/"'
+# chezmoi wrapper for the private/work dotfiles source (no-op if it isn't cloned)
+alias czw='chezmoi --source ~/.local/share/chezmoi-work --config ~/.config/chezmoi/chezmoi-work.toml'

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -50,8 +50,9 @@ if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then
     source $HOME/google-cloud-sdk/path.zsh.inc
 fi
 
-if [ -f "$HOME/acrisure/zsh_env" ]; then
-    source $HOME/acrisure/zsh_env
+# Load local/work overrides if present (managed in a separate private repo)
+if [ -d "$HOME/.config/zsh/local" ]; then
+    for f in "$HOME"/.config/zsh/local/*.zsh(N); do source "$f"; done
 fi
 # }}}
 
@@ -69,7 +70,5 @@ export EDITOR="$(which nvim)"
 
 bindkey -v
 bindkey '^ ' autosuggest-accept
-export SPRING_PROFILES_ACTIVE=local
 
-export NODE_EXTRA_CA_CERTS="$HOME/certs/zscaler-root-ca.pem"
 export CLAUDE_CODE_NO_FLICKER=1


### PR DESCRIPTION
Splits all Acrisure/company-specific dotfiles out of this public repo into a private second chezmoi source (`github.com/phlemons/acrisure-dotfiles`), so nothing company-identifying lands here.

## Changes
- **`.zshrc`**: replace the hardcoded `~/acrisure/zsh_env` source with a generic `~/.config/zsh/local/*.zsh` loader; drop the zscaler CA, Spring profile, and Obsidian/OneDrive env exports (moved to the private source).
- **`.zsh/zsh_alias`**: drop the `kafka` alias (moved to private); add a generic `czw` bootstrap alias for the private chezmoi source.
- **`dot_claude/CLAUDE.md` → `CLAUDE.md.tmpl`**: keep only generic rules (Git Push, generic Volta); conditionally `@import work-rules.md` when `.work` is true. Company rules (Jira ATG prefixing, clover Volta specifics, Obsidian vault) moved to the private source.
- **`.chezmoi.toml.tmpl`**: add a `work` prompt (`promptBoolOnce`) to gate the import per machine.
- Company Claude `settings.json`, `commands/`, and `skills/` moved to the private source.

## Verification
- `git grep` for `acrisure|altway|zscaler|prj-[cd]-secrets|cloud-sql|onedrive` over the tracked tree returns **zero** matches.
- Applied on a work machine and confirmed a fresh shell still loads all work env vars, the three secrets (now age-encrypted in the private repo), and the `kafka` alias.

## Notes
- Already-published history (older GCP project IDs / Cloud SQL names) is intentionally **not** rewritten — pending an infosec check.
- Real secrets are now age-encrypted in the private repo; the plaintext `~/acrisure/zsh_env` has been deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)